### PR TITLE
Fix Pubscreen Undefined Check for New Publication

### DIFF
--- a/src/app/pubScreen/pubScreen.component.ts
+++ b/src/app/pubScreen/pubScreen.component.ts
@@ -732,7 +732,7 @@ export class PubScreenComponent implements OnInit, OnDestroy {
 
     // Opening Dialog for adding a new publication.
     openDialogAddPublication(Publication?: any): void {
-        if (Publication == 'undefined') {
+        if (Publication == undefined) {
             Publication = null;
         }
         let dialogref = this.dialog.open(PubscreenDialogeComponent, {


### PR DESCRIPTION
Issue: Adding publication attempted to trigger edit mode.
Cause: The initial check for a Publication argument in Add publication used 'undefined' instead of undefined. 
Fix: Remove the parentheses