### PR TITLE
Improved Cogbytes Metadata collection

### DIFF
--- a/Controllers/CogbytesController.cs
+++ b/Controllers/CogbytesController.cs
@@ -322,6 +322,15 @@ namespace AngularSPAWebAPI.Controllers
 
         }
 
+        [AllowAnonymous]
+        [HttpGet("GetMetaDataByLinkGuid")]
+        public IActionResult GetMetaDataByLinkGuid(Guid repoLinkGuid)
+        {
+             // extract data from database to show in the client
+            return new JsonResult(_cogbytesService.GetMetaDataFromCogbytesByLinkGuid(repoLinkGuid));
+
+        }
+
         // Function Definition to get repo's Guid based on Repo ID
         [AllowAnonymous]
         [HttpGet("GetGuidByRepID")]

--- a/Models/CogbytesMetaData.cs
+++ b/Models/CogbytesMetaData.cs
@@ -1,0 +1,26 @@
+using CBAS.Models;
+using Microsoft.AspNetCore.Identity;
+using System;
+
+namespace AngularSPAWebAPI.Models
+{
+    public class CogBytesMetaData
+    {
+        public int RepoID { get; set; }
+        public Guid RepoLinkGuid { get; set; }
+        public string Title { get; set; }
+        public string Date { get; set; }
+        public string DOI { get; set; }
+        public string Keywords { get; set; }
+        public bool PrivacyStatus { get; set; }
+        public string Description { get; set; }
+        public string AdditionalNotes { get; set; }
+        public string Link { get; set; }
+        public string Username { get; set; }
+        public string DateRepositoryCreated { get; set; }
+        public string Author { get; set; }
+        public string PI { get; set; }
+        public System.Collections.Generic.List<Experiment> Experiment { get; set; }
+        public PubScreenSearch Paper { get; set; }
+    }
+}

--- a/Models/CogbytesSearch2.cs
+++ b/Models/CogbytesSearch2.cs
@@ -10,18 +10,6 @@ namespace AngularSPAWebAPI.Models
         public int RepoID { get; set; }
         public Guid RepoLinkGuid { get; set; }
         public int UploadID { get; set; }
-        public string Title { get; set; }
-        public string Date { get; set; }
-        public string DOI { get; set; }
-        public string Keywords { get; set; }
-        public bool PrivacyStatus { get; set; }
-        public string Description { get; set; }
-        public string AdditionalNotes { get; set; }
-        public string Link { get; set; }
-        public string Username { get; set; }
-        public string DateRepositoryCreated { get; set; }
-        public string Author { get; set; }
-        public string PI { get; set; }
         public string UploadName { get; set; }
         public string DateUpload { get; set; }
         public string UploadDescription { get; set; }
@@ -39,8 +27,6 @@ namespace AngularSPAWebAPI.Models
         public string GenoType { get; set; }
         public string Age { get; set; }
         public int? NumSubjects { get; set; }
-        public System.Collections.Generic.List<Experiment> Experiment { get; set; }
-        public PubScreenSearch Paper { get; set; }
 
         public System.Collections.Generic.List<FileUploadResult> UploadFileList { get; set; }
 

--- a/Services/CogbytesService.cs
+++ b/Services/CogbytesService.cs
@@ -1271,9 +1271,6 @@ namespace AngularSPAWebAPI.Services
                         numSubjects = num;
                     };
 
-                    string doi = Convert.ToString(dr["DOI"].ToString());
-                    PubScreenSearch publication = GetPubScreenPaper(doi);
-
                     // Loop through table UploadFile to get list of all files uploaded to each Upload section in a Repo
                     List<FileUploadResult> FileList = new List<FileUploadResult>();
                     using (DataTable ft = Dal.GetDataTableCog($@"Select * From UploadFile Where UploadID={UploadID} Order By DateUploaded"))
@@ -1296,21 +1293,9 @@ namespace AngularSPAWebAPI.Services
 
                     RepList.Add(new CogbytesSearch2
                     {
-                        RepoID = repID,
+                        RepoID = Int32.Parse(dr["RepID"].ToString()),
                         RepoLinkGuid = repoLinkGuid,
                         UploadID = UploadID,
-                        Title = Convert.ToString(dr["Title"].ToString()),
-                        Date = Convert.ToString(dr["Date"].ToString()),
-                        DOI = doi,
-                        Keywords = Convert.ToString(dr["Keywords"].ToString()),
-                        PrivacyStatus = Boolean.Parse(dr["PrivacyStatus"].ToString()),
-                        Description = Convert.ToString(dr["Description"].ToString()),
-                        AdditionalNotes = Convert.ToString(dr["AdditionalNotes"].ToString()),
-                        Link = Convert.ToString(dr["Link"].ToString()),
-                        Username = Convert.ToString(dr["Username"].ToString()),
-                        DateRepositoryCreated = Convert.ToString(dr["DateRepositoryCreated"].ToString()),
-                        Author = Convert.ToString(dr["Author"].ToString()),
-                        PI = Convert.ToString(dr["PI"].ToString()),
                         UploadName = Convert.ToString(dr["UploadName"].ToString()),
                         DateUpload = Convert.ToString(dr["DateUpload"].ToString()),
                         UploadDescription = Convert.ToString(dr["UploadDescription"].ToString()),
@@ -1328,9 +1313,7 @@ namespace AngularSPAWebAPI.Services
                         GenoType = Convert.ToString(dr["GenoType"].ToString()),
                         Age = Convert.ToString(dr["Age"].ToString()),
                         UploadFileList = FileList,
-                        Experiment = GetCogbytesExperimentList(repoLinkGuid),
-                        NumSubjects = numSubjects,
-                        Paper = publication
+                        NumSubjects = numSubjects
                     });
 
                 }
@@ -1340,7 +1323,38 @@ namespace AngularSPAWebAPI.Services
 
         }
 
+        public List<CogBytesMetaData> GetMetaDataFromCogbytesByLinkGuid(Guid repoLinkGuid) {
+            List<CogBytesMetaData> RepList = new List<CogBytesMetaData>();
+            using (DataTable dt = Dal.GetDataTableCog($@"Select * From SearchCogMeta Where RepoLinkGuid = '{repoLinkGuid}'"))
+            {
+                foreach (DataRow dr in dt.Rows)
+                {
+                    string doi = Convert.ToString(dr["DOI"].ToString());
+                    PubScreenSearch publication = GetPubScreenPaper(doi);
+                    RepList.Add(new CogBytesMetaData
+                    {
+                        RepoID = Int32.Parse(dr["RepID"].ToString()),
+                        RepoLinkGuid = repoLinkGuid,
+                        Title = Convert.ToString(dr["Title"].ToString()),
+                        Date = Convert.ToString(dr["Date"].ToString()),
+                        DOI = doi,
+                        Keywords = Convert.ToString(dr["Keywords"].ToString()),
+                        PrivacyStatus = Boolean.Parse(dr["PrivacyStatus"].ToString()),
+                        Description = Convert.ToString(dr["Description"].ToString()),
+                        AdditionalNotes = Convert.ToString(dr["AdditionalNotes"].ToString()),
+                        Link = Convert.ToString(dr["Link"].ToString()),
+                        Username = Convert.ToString(dr["Username"].ToString()),
+                        DateRepositoryCreated = Convert.ToString(dr["DateRepositoryCreated"].ToString()),
+                        Author = Convert.ToString(dr["Authors"].ToString()),
+                        PI = Convert.ToString(dr["PIs"].ToString()),
+                        Experiment = GetCogbytesExperimentList(repoLinkGuid),
+                        Paper = publication
 
+                    });
+                }
+            }
+            return RepList;
+        }
 
         public async Task<Cogbytes> GetGuidByRepID(int repID)
         {

--- a/src/app/cogbytesEdit/cogbytesEdit.component.html
+++ b/src/app/cogbytesEdit/cogbytesEdit.component.html
@@ -21,7 +21,7 @@
 
         <tbody class="docs-markdown-tbody">
             <ng-container>
-                <tr style="border-bottom:1pt solid #8D8E90;" *ngIf="repoList?.length > 0">
+                <tr style="border-bottom:1pt solid #8D8E90;">
                     <td>
                         <label><b>Repository Information:</b></label><br /><br />
                         <label>Title:</label> &nbsp; <span style="color:#696d70;">{{( repObj?.title ==="") ?  "N/A" : repObj.title}}</span> &nbsp; &nbsp; &nbsp;

--- a/src/app/cogbytesEdit/cogbytesEdit.component.ts
+++ b/src/app/cogbytesEdit/cogbytesEdit.component.ts
@@ -63,13 +63,13 @@ export class CogbytesEditComponent implements OnInit {
         this.spinnerService.show();
 
         this.cogbytesService.getDataByLinkGuid(repoLinkGuid).subscribe((data : any) => {
-
-            this.repObj = data[0];
             this.repoList = data;
-            //console.log(this.repObj);
-            //console.log(this.repoList);
 
         });
+
+        this.cogbytesService.getMetaDataByLinkGuid(repoLinkGuid).subscribe((data: any) => {
+            this.repObj = data[0];
+        })
 
         this.spinnerService.hide();
 

--- a/src/app/services/cogbytes.service.ts
+++ b/src/app/services/cogbytes.service.ts
@@ -288,6 +288,14 @@ import { AuthenticationService } from './authentication.service';
             });
     }
 
+    public getMetaDataByLinkGuid(repoLinkGuid: any): any {
+        return this.http
+            .get("/api/Cogbytes/GetMetaDataByLinkGuid?repoLinkGuid=" + repoLinkGuid, {
+                // headers: this.authenticationService.getAuthorizationHeader()
+                headers: new HttpHeaders().set('Content-Type', 'application/json')
+            });
+    }
+
 
     public getGuidByRepID(repID: number): any {
 


### PR DESCRIPTION
Created separate API call for pulling CogBytes repository metadata. In previous iteration the metadata was collected multiple times for every upload category. This also results in Cogbytes repositories not being visible if no files are present, despite datasets being linked together.

Changes:

- Added function in Cogbytes service to handle metadata.
- Removed metadata from data table search for file upload information.
- Removed restriction of file upload > 0 for displaying cogbytes edit page.

** Note: This change requires a new Table View in the CogBytes SQL database. The relevant code for the table view is included in the attached SQL file. 

[Cogbytes - Meta Table.txt](https://github.com/user-attachments/files/19981413/Cogbytes.-.Meta.Table.txt)
