### PR TITLE
Fixed Spotfire Page Switch

### DIFF
--- a/src/app/data-visualization/data-visualization.component.html
+++ b/src/app/data-visualization/data-visualization.component.html
@@ -32,7 +32,7 @@
         <tr>
             <td>
                 <div class="main">
-                    <div id="contentpanel" class="webPlayerCss"></div>
+                    <div id="datavisual-dashboard-container" class="webPlayerCss"></div>
                 </div>
             </td>
         </tr>

--- a/src/app/data-visualization/data-visualization.component.ts
+++ b/src/app/data-visualization/data-visualization.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core'; // Import OnDestroy
 declare var spotfire: any;
 import { NgxSpinnerService } from 'ngx-spinner';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -11,7 +11,7 @@ import { User } from '../models/user'
     templateUrl: './data-visualization.component.html',
     styleUrls: ['./data-visualization.component.scss']
 })
-export class DataVisualizationComponent implements OnInit {
+export class DataVisualizationComponent implements OnInit, OnDestroy {
 
     selectedCogTaskValue: any = '';
     app: any;
@@ -24,19 +24,6 @@ export class DataVisualizationComponent implements OnInit {
         { cogTaskID: 3, name: 'PD' },
         { cogTaskID: 4, name: 'iCPT' }
     ];
-
-    //private filteringSchemeNames: any = {
-    //    "1": "Filtering scheme (1)",
-    //    "2": "Filtering scheme (2)",
-    //    "3": "Filtering scheme (3)"
-    //};
-
-    //private dataTableNames: any = {
-    //    "1": "vw_dPALsPAL_visualization",
-    //    "2": "vw_dPALsPAL_visualization"
-    //};
-
-    //dataColumnName: "ExpName";
 
 
     constructor(
@@ -61,6 +48,10 @@ export class DataVisualizationComponent implements OnInit {
         });
 
 
+    }
+
+    ngOnDestroy() {
+        this.destroySpotfireApplication();
     }
 
     selectCogTaskChange(reload : any) {
@@ -91,124 +82,45 @@ export class DataVisualizationComponent implements OnInit {
     }
 
     loadAnalysis(spotfireAnalysisName: string) {
+        this.destroySpotfireApplication();
 
-        //console.log('loaded');
         var customization = new spotfire.webPlayer.Customization();
-        //customization.showCustomizableHeader = false;
-        //customization.showToolBar = false;
         customization.showClose = false;
-        //customization.showTopHeader = false;
-
-        //customization.showTopHeader = false;
-
-        //customization.showToolBar = true;
-
-        //customization.showAbout = false;
-        //customization.showAnalysisInfo = false;
-        //customization.showAnalysisInformationTool = false;
-        //customization.showClose = false;
-        //customization.showCustomizableHeader = false;
         customization.showDodPanel = false;
-
-        //customization.showExportFile = true;
-
-        //customization.showExportVisualization = false;
-        //customization.showFilterPanel = true;
         customization.showHelp = false;
-        //customization.showLogout = false;
-        //customization.showPageNavigation = false;
         customization.showReloadAnalysis = true;
         customization.showStatusBar = false;
-        //customization.showUndoRedo = false;
         customization.showCollaboration = false;
 
         this.app = new spotfire.webPlayer.Application("https://mouse.robarts.ca/spotfire/wp/", customization);
         var configuration = 'mbusername="' + this.user.userName + '";';
-
-        var onError = function (errorCode : any, description : any) {
+        // Use arrow functions to preserve the 'this' context of the DataVisualizationComponent
+        const onError = (errorCode : any, description : any) => {
             console.log('<span style="color: red;">[' + errorCode + "]: " + description + "</span>");
+            this.spinnerService.hide();
         };
-        var onOpenedfunction = function () {
+        const onOpenedfunction = () => {
             //console.log('onopened');
+            this.spinnerService.hide();
         };
 
         this.app.onError(onError);
         this.app.onOpened(onOpenedfunction);
 
 
-        this.app.open("/Public/User_Based_Visualizations/" + spotfireAnalysisName, "contentpanel", configuration);
-
-        // 1. click btn -> getActiveFilteringScheme -> get which items are checked and add them to query string masalan: https://mousebytes.ca/data-visualization?taskid=2&sara=1,3
-        // 2. when user comes to this page with querystring set, get values from querystring and set filters
-
-
-        this.spinnerService.hide();
-
+        this.app.open("/Public/User_Based_Visualizations/" + spotfireAnalysisName, "datavisual-dashboard-container", configuration);
     }
 
-    //GenerateLink() {
-    //    // get filter
-    //    if (this.selectedCogTaskValue == 1) { // 5-CSRTT
-
-    //    } if (this.selectedCogTaskValue == 2) { //PAL
-
-    //    } if (this.selectedCogTaskValue == 3) { // PD
-
-    //    }
-    //    //var filterQuerystring = "";
-    //    //this.app.analysisDocument.filtering.getActiveFilteringScheme(
-    //    //    function (args) {
-    //    //        console.log('test');
-    //    //        args.getDefaultFilterColumns(
-    //    //            spotfire.webPlayer.includedFilterSettings.ALL_WITH_UNCHECKED_HIERARCHY_NODES,
-    //    //            function (args2) {
-    //    //                console.log(args2); //log(dump(args2, "spotfire.webPlayer.Document.FilteringScheme.getDefaultFilterColumns", 2));
-
-    //    //                // this is to select ExpName filter
-    //    //                var expNameFilter = args2.filter(obj => {
-    //    //                    return obj.dataColumnName === "ExpName"
-    //    //                })
-
-    //    //                console.log(expNameFilter);
-    //    //                console.log(expNameFilter[0]);
-    //    //                console.log(expNameFilter[0].filterSettings);
-    //    //                console.log(expNameFilter[0].filterSettings.values);
-    //    //                console.log(expNameFilter[0].filterSettings.values.toString());
-
-    //    //                filterQuerystring = "&filters=" + expNameFilter[0].filterSettings.values.toString();
-
-
-    //    //            });
-    //    //    });
-
-    //    //this.dialogRefLink = this.dialog.open(NotificationDialogComponent, {
-    //    //});
-
-    //    //this.dialogRefLink.componentInstance.message = "https://mousebytes.ca/" + "?taskid=" + this.selectedCogTaskValue + filterQuerystring;
-
-
-
-    //};
-    //function getFilteringScheme("Filtering scheme Reversal", callback);
-
-    //SetFilters() {
-    //    // set filter
-    //    var filterColumn = {
-    //        filteringSchemeName: "Filtering scheme (2)",
-    //        dataTableName: "vw_dPALsPAL_visualization",
-    //        dataColumnName: "ExpName",
-    //        filteringOperation: spotfire.webPlayer.filteringOperation.REPLACE,
-    //        filterSettings: {
-    //            includeEmpty: true,
-    //            values: ["DP_AD_PAL", "FB_AD_PAL"]
-    //        }
-    //    };
-
-    //    var filteringOperation = spotfire.webPlayer.filteringOperation.REPLACE;
-    //    this.app.analysisDocument.filtering.setFilter(
-    //        filterColumn,
-    //        filteringOperation);
-    //    console.log("[spotfire.webPlayer.Document.Filtering.setFilter]");
-
-    //}
+    private destroySpotfireApplication() {
+        if (this.app) {
+            if (typeof this.app.close == 'function') {
+                this.app.close();
+            }
+            this.app = null;
+        }
+        const contentPanel = document.getElementById("datavisual-dashboard-container");
+        if (contentPanel) {
+            contentPanel.innerHTML = "";
+        }
+    }
 }

--- a/src/app/mb-dashboard/mb-dashboard.component.html
+++ b/src/app/mb-dashboard/mb-dashboard.component.html
@@ -13,7 +13,7 @@
         <tr>
             <td>
                 <div class="main">
-                    <div id="contentpanel" class="webPlayerCss"></div>
+                    <div id="mousebytes-dashboard-container" class="webPlayerCss"></div>
                 </div>
             </td>
         </tr>

--- a/src/app/mb-dashboard/mb-dashboard.component.ts
+++ b/src/app/mb-dashboard/mb-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { NgxSpinnerService } from 'ngx-spinner';
 import { Router, ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
@@ -10,7 +10,7 @@ declare var spotfire: any;
     templateUrl: './mb-dashboard.component.html',
     styleUrls: ['./mb-dashboard.component.scss']
 })
-export class MBDashboardComponent implements OnInit {
+export class MBDashboardComponent implements OnInit, OnDestroy {
 
     app: any;
 
@@ -26,8 +26,13 @@ export class MBDashboardComponent implements OnInit {
 
     ngOnInit() {
 
+        this.spinnerService.show();
         this.loadAnalysis("View_MB_Data")
         
+    }
+
+    ngOnDestroy() {
+        this.destroySpotfireApplication();
     }
 
     
@@ -35,32 +40,10 @@ export class MBDashboardComponent implements OnInit {
 
         //console.log('loaded');
         var customization = new spotfire.webPlayer.Customization();
-        //customization.showCustomizableHeader = false;
-        //customization.showToolBar = false;
         customization.showClose = false;
-        //customization.showTopHeader = false;
-
-        //customization.showTopHeader = false;
-
-        //customization.showToolBar = true;
-
-        //customization.showAbout = false;
-        //customization.showAnalysisInfo = false;
-        //customization.showAnalysisInformationTool = false;
-        //customization.showClose = false;
-        //customization.showCustomizableHeader = false;
         customization.showDodPanel = false;
-
-        //customization.showExportFile = true;
-
-        //customization.showExportVisualization = false;
-        //customization.showFilterPanel = true;
         customization.showHelp = false;
-        //customization.showLogout = false;
-        //customization.showPageNavigation = false;
-        customization.showReloadAnalysis = true;
         customization.showStatusBar = false;
-        //customization.showUndoRedo = false;
         customization.showCollaboration = false;
 
         this.app = new spotfire.webPlayer.Application("https://mouse.robarts.ca/spotfire/wp/", customization);
@@ -77,12 +60,23 @@ export class MBDashboardComponent implements OnInit {
         this.app.onOpened(onOpenedfunction);
 
 
-        this.app.open("/Public/" + spotfireAnalysisName, "contentpanel", configuration);
+        this.app.open("/Public/" + spotfireAnalysisName, "mousebytes-dashboard-container", configuration);
 
        
         this.spinnerService.hide();
 
     }
 
-   
+    private destroySpotfireApplication() {
+        if (this.app) {
+            if (typeof this.app.close === 'function') {
+                this.app.close();
+            }
+            this.app = null;
+        }
+        const contentPanel = document.getElementById("mousebytes-dashboard-container");
+        if (contentPanel) {
+            contentPanel.innerHTML = "";
+        }
+    }
 }

--- a/src/app/pubScreen-dashboard/pubScreen-dashboard.component.html
+++ b/src/app/pubScreen-dashboard/pubScreen-dashboard.component.html
@@ -13,7 +13,7 @@
         <tr>
             <td>
                 <div class="main">
-                    <div id="contentpanel" class="webPlayerCss"></div>
+                    <div id="pubscreen-dashboard-container" class="webPlayerCss"></div>
                 </div>
             </td>
         </tr>


### PR DESCRIPTION
Update to mb-dashboard, pubScreen-dashboard, and data-visualization components. Fix includes:
- Implements onDestroy to ensure that spotfire instances are shutdown between navigation.
- Renames div elements to unique names to ensure application recognizes new instances
- removed showReloadAnalysis (depracated)