### PR TITLE
Resolve Sub Experiment Creation with No Images

### DIFF
--- a/src/app/sub-exp-dialoge/sub-exp-dialoge.component.ts
+++ b/src/app/sub-exp-dialoge/sub-exp-dialoge.component.ts
@@ -61,7 +61,7 @@ export class SubExpDialogeComponent implements OnInit {
         this.drugQuantity = fb.control('', [Validators.required]);
         this.drugUnit = fb.control('', [Validators.required]);
         this.intDes = fb.control('', [Validators.required]);
-        this.imageInfo = fb.control('', [Validators.required]);
+        this.imageInfo = fb.control([], [Validators.required]);
         this.imageDescription = fb.control('', [Validators.required]);
         this.housing = fb.control('', [Validators.required]);
         this.lightCycle = fb.control('', [Validators.required]);


### PR DESCRIPTION
Bug: Sub Experiments could not be created if task did not use images (5-Choice, PRL, PVD)
Cause: Sub Experiment form control was using string as default
Solution: Replace form control default to empty array